### PR TITLE
Relax minor version in dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 tests_require = [
-    'pycodestyle>=2.5.0'
+    'pycodestyle~=2.5'
 ]
 
 setup(
@@ -25,11 +25,11 @@ setup(
         ]
     },
     install_requires=[
-        'webviz-config>=0.0.4'
+        'webviz-config~=0.0.4'
     ],
     tests_require=tests_require,
     extras_require={'tests': tests_require},
-    setup_requires=['setuptools_scm>=3.2.0'],
+    setup_requires=['setuptools_scm~=3.2'],
     use_scm_version=True,
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         ]
     },
     install_requires=[
-        'webviz-config~=0.0.4'
+        'webviz-config>=0.0.4'
     ],
     tests_require=tests_require,
     extras_require={'tests': tests_require},


### PR DESCRIPTION
Currently some requirements versions are given as `~= x.y.z`. This increases likelihood of version conflicts. Assuming dependencies are well behaving with respect to semantic versioning, it is better to state `~= x.y` in order to reduce risk of verson conflict. 

See [PEP 440](https://www.python.org/dev/peps/pep-0440/#compatible-release) for more information on compatible version specifiers.