### PR TITLE
Fix loading widget to viewport

### DIFF
--- a/webviz_config_equinor/assets/equinor_theme.css
+++ b/webviz_config_equinor/assets/equinor_theme.css
@@ -2,7 +2,7 @@
 
   animation: fadein 4.0s;
 
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
Resolves #9. Loading-state animation now follows the scroll/viewport. Dash makes sure `100%` width/height fills the body, making sure we don't get problems with e.g. `100vw` and if that includes/not includes scroll bar width (if it exist).