### PR TITLE
Extend CI to Python{3.7, 3.8}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ addons:
 
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 
-matrix:
+jobs:
   fast_finish: true
+  allow_failures:
+    - python: "3.8"
 
 before_install:
   - sudo apt-get -qq update
@@ -24,4 +28,5 @@ deploy:
     password:
       secure: RcB40fO+hek+prhJZ1dlaoazZ6Kf/l6Hrt5Xw4UDtrPXOeaG1BSS+CcS2u7s6Hhbrj77HnQTjVreOY63Iw8UW3wc0vpIkaAyqcZ9dXdjsR45G/p43jSmoc6oPK26W7H1sOb7hJYhZ5rWI0pMcmAs+9RVncj4hZaKBr0sieJTvBn+zfWfghayTv0USR5J2C7HYGCsEbZjBdtahGssFMGr/MOYWSCYePQ8QsZo0qm/1rEbAOYilaBz4lmanvW444FOl2mcH9cPVbNT97gnQzSVs9vHIhmZY1Zos3cV2ymrh8M5CG4qXAY58lAJPyGWPsBeulBeD4kiqNp4c+CknPlDi1tPv0boxHlBs7WVlJjLETITKS/uyGRaIuMFix5pH1XlTAZ9F/LM1Em/lPOAeL7xg6PqTggwA7mL3Y0ITIiq/5QmedxyGatrCG2pQtFF9pFmMQ7pkgrN/qETVT4A1dwXb0RREEiQfmFBWaK+aM+05gjw3mzX+dTUuebxYga5mG99qs3shGDthwUIEKGV7GvlR4F97fRPNLN7F2hvgYffqH4qUg+zUc+5dirFpKPYM1mdd638JcVUbYZw/c3KmjUJp5CA4Ozh4cQ9b1iNv1Hp1DjlYNM4yp6LwDppMsHsAMFtW66og548yMhJELhw3DoM+QuHaixlLEvMZfEx1vbz6a4=
     on:
+      python: "3.6"
       tags: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![PyPI version](https://badge.fury.io/py/webviz-config-equinor.svg)](https://badge.fury.io/py/webviz-config-equinor)
 [![Build Status](https://travis-ci.org/equinor/webviz-config-equinor.svg?branch=master)](https://travis-ci.org/equinor/webviz-config-equinor)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/eafe7dfd1b274c02a78de59bb8b8778f)](https://www.codacy.com/app/anders-kiaer/webviz-config-equinor?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=equinor/webviz-config-equinor&amp;utm_campaign=Badge_Grade)
-[![Python 3.6+](https://img.shields.io/badge/python-3.6+-blue.svg)](https://www.python.org/)
+[![Python 3.6 | 3.7](https://img.shields.io/badge/python-3.6%20|%203.7-blue.svg)](https://www.python.org/)
 ![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
 
 # Webviz config theme for Equinor


### PR DESCRIPTION
Currently running only CI on Python `3.6`. Extend to `[3.6, 3.7, 3.8]`.

`3.8` is set to currently be allowed to fail, as one or more upstream dependencies are not yet available for Python 3.8.