### PR TITLE
Block labels

### DIFF
--- a/webviz_config_equinor/assets/equinor_theme.css
+++ b/webviz_config_equinor/assets/equinor_theme.css
@@ -238,3 +238,13 @@ tr:nth-child(odd) {
   border-color: var(--menuLinkBackgroundHover);
 }
 
+label, legend {
+  display: block;
+  margin-bottom: 0px;
+}
+
+label > .label-body {
+  display: inline-block;
+  margin-left: 0.5rem;
+  font-weight: normal;
+}


### PR DESCRIPTION
Fix after regression bug in #28, such that we go from this:
![image](https://user-images.githubusercontent.com/31612826/78073157-a21d1d00-73a0-11ea-8078-ff9fdb7c3bae.png)
to this:
![image](https://user-images.githubusercontent.com/31612826/78073123-92053d80-73a0-11ea-8dd3-6f9a34ea1005.png)
