### PR TITLE
SI exponent format xaxis+yaxis+colorbar in layout 

### DIFF
--- a/webviz_config_equinor/__init__.py
+++ b/webviz_config_equinor/__init__.py
@@ -77,5 +77,8 @@ equinor_theme.plotly_theme = {
             "#D5EAF4",
             "#FF88A1",
         ],
+        "xaxis": {"exponentformat": "SI"},
+        "yaxis": {"exponentformat": "SI"},
+        "coloraxis": {"colorbar": {"exponentformat": "SI"}},
     }
 }


### PR DESCRIPTION
Added `SI` as `exponentformat` for `xaxis` and `yaxis`. Possible to use through [new feature in webviz-config](https://github.com/equinor/webviz-config/pull/219). Writes e.g. G for 10^9 instead of B which is the Plotly default. 