### PR TITLE
Scope table CSS

### DIFF
--- a/webviz_config_equinor/assets/equinor_theme.css
+++ b/webviz_config_equinor/assets/equinor_theme.css
@@ -129,7 +129,6 @@ hr {
   z-index: 9999;
 }
 
-
 @keyframes fadein {
     0%   { opacity: 0; }
     40%  { opacity: 0; }
@@ -155,50 +154,35 @@ div.styledLogo.tab {
     padding: 20px 30px;
 }
 
-/* 
-    Equinor branded table 
-
-    As of dash-table 3.6.0, styles are made inline. Therefore the use
-    of !important to override dash-table default style with Equinor style.
-
-    When inline styles are removed from dash data-table, the !important
-    statement can be removed.
-*/
-
-table {
+.webviz-config-markdown table {
     color: rgb(51, 51, 51);
     border: solid white;
     border-collapse: collapse;
     font-variant-numeric: tabular-nums;
 }
 
-td {
-    padding: 10px !important;  /* csslint allow: important */
+.webviz-config-markdown td {
+    padding: 10px;
     margin: 5px;
     border: 1px solid white;
-    box-shadow: none !important;  /* csslint allow: important */
+    box-shadow: none;
 }
 
-th {
-    background-color: rgb(255, 18, 67) !important;  /* csslint allow: important */
+.webviz-config-markdown th {
+    background-color: rgb(255, 18, 67);
     color: white;
-    padding: 10px !important;  /* csslint allow: important */
+    padding: 10px;
     margin: 5px;
     border: 1px solid white;
-    box-shadow: none !important;  /* csslint allow: important */
+    box-shadow: none;
 }
 
-tr:nth-child(even) {
-    background-color: rgb(255, 204, 207) !important;  /* csslint allow: important */
+.webviz-config-markdown tr:nth-child(even) {
+    background-color: rgb(255, 204, 207);
 }
 
-tr:nth-child(odd) {
-    background-color: rgb(255, 231, 231) !important;  /* csslint allow: important */
-}
-
-.dash-header th, .dash-header span, .dash-filter input {
-    font-weight: bold !important;  /* csslint allow: important */
-    color: white !important;  /* csslint allow: important */
+.webviz-config-markdown tr:nth-child(odd) {
+    background-color: rgb(255, 231, 231);
 }
 
 .button, button, input[type=submit], input[type=reset], input[type=button] {


### PR DESCRIPTION
Reducing scope of `table` CSS to where it is being used (content from the markdown plugin). 

Global scope makes it difficult to "remove" the `table` CSS from applications where it is not needed/wanted (like in complex tooltips with tabular data).

Also removing the `!important` for Dash `DataTable`, falling back to default Dash inline style. If we want to change it, we should probably ask in the `DataTable` repository and/or suggest a PR there.

![tooltip_well_completion](https://user-images.githubusercontent.com/31612826/115903547-ff7c8400-a463-11eb-85ae-0c9de0fe2b18.png)
