### PR TITLE
Removed global style of `label` and `legend` elements

### DIFF
--- a/webviz_config_equinor/assets/equinor_theme.css
+++ b/webviz_config_equinor/assets/equinor_theme.css
@@ -222,13 +222,3 @@ div.styledLogo.tab {
   background-color: var(--menuLinkBackgroundHover);
   border-color: var(--menuLinkBackgroundHover);
 }
-
-label, legend {
-  margin-bottom: 0px;
-}
-
-label > .label-body {
-  display: inline-block;
-  margin-left: 0.5rem;
-  font-weight: normal;
-}

--- a/webviz_config_equinor/assets/equinor_theme.css
+++ b/webviz_config_equinor/assets/equinor_theme.css
@@ -224,7 +224,6 @@ div.styledLogo.tab {
 }
 
 label, legend {
-  display: block;
   margin-bottom: 0px;
 }
 


### PR DESCRIPTION
Removed display: block from label, legend in the equinor_theme.css file. 

The purpose is to fix an issue in the tree selector in the well completions plugin in webviz-subsurface.